### PR TITLE
chore: transfer to @kintone/plugin-manifest-validator

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Cybozu, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-kintone-plugin-manifest-validator
+@kintone/plugin-manifest-validator
 ====
 
 Validate `manifest.json` of kintone plugin. Used in [kintone-plugin-packer](https://github.com/teppeis/kintone-plugin-packer).
@@ -19,7 +19,7 @@ $ npm install @teppeis/kintone-plugin-packer
 ## Usage
 
 ```js
-const validator = require('@teppeis/kintone-plugin-manifest-validator');
+const validator = require('@kintone/plugin-manifest-validator');
 
 const manifestJson = require('path/to/your/manifest.json');
 const result = validator(manifestJson);
@@ -44,27 +44,22 @@ console.log(result.errors); // array of ajv error objects
 ## `manifest-json.d.ts`
 
 ```js
-import {KintonePluginManifestJson} from '@teppeis/kintone-plugin-manifest-validator/manifest-schema';
+import {KintonePluginManifestJson} from '@kintone/plugin-manifest-validator/manifest-schema';
 
 let manifest: KintonePluginManifestJson;
 ```
 
 ## License
 
-MIT License: Teppei Sato &lt;teppeis@gmail.com&gt;
+MIT License
 
-[npm-image]: https://img.shields.io/npm/v/@teppeis/kintone-plugin-manifest-validator.svg
-[npm-url]: https://npmjs.org/package/@teppeis/kintone-plugin-manifest-validator
-[npm-downloads-image]: https://img.shields.io/npm/dm/@teppeis/kintone-plugin-manifest-validator.svg
-[travis-image]: https://img.shields.io/travis/teppeis/kintone-plugin-manifest-validator/master.svg
-[travis-url]: https://travis-ci.org/teppeis/kintone-plugin-manifest-validator
-[circleci-image]: https://circleci.com/gh/teppeis/kintone-plugin-manifest-validator.svg?style=shield
-[circleci-url]: https://circleci.com/gh/teppeis/kintone-plugin-manifest-validator
+[npm-image]: https://img.shields.io/npm/v/@kintone/plugin-manifest-validator.svg
+[npm-url]: https://npmjs.org/package/@kintone/plugin-manifest-validator
+[circleci-image]: https://circleci.com/gh/kintone/plugin-manifest-validator.svg?style=shield
+[circleci-url]: https://circleci.com/gh/kintone/plugin-manifest-validator
 [appveyor-image]: https://ci.appveyor.com/api/projects/status/pcsvpsj4ff8u4jop/branch/master?svg=true
 [appveyor-url]: https://ci.appveyor.com/project/teppeis/kintone-plugin-manifest-validator/branch/master
-[deps-image]: https://img.shields.io/david/teppeis/kintone-plugin-manifest-validator.svg
-[deps-url]: https://david-dm.org/teppeis/kintone-plugin-manifest-validator
+[deps-image]: https://img.shields.io/david/kintone/plugin-manifest-validator.svg
+[deps-url]: https://david-dm.org/kintone/plugin-manifest-validator
 [node-version]: https://img.shields.io/badge/Node.js%20support-v6,v8,v10-brightgreen.svg
-[coverage-image]: https://img.shields.io/coveralls/teppeis/kintone-plugin-manifest-validator/master.svg
-[coverage-url]: https://coveralls.io/github/teppeis/kintone-plugin-manifest-validator?branch=master
-[license]: https://img.shields.io/npm/l/@teppeis/kintone-plugin-manifest-validator.svg
+[license]: https://img.shields.io/npm/l/@kintone/plugin-manifest-validator.svg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@teppeis/kintone-plugin-manifest-validator",
+  "name": "@kintone/plugin-manifest-validator",
   "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@teppeis/kintone-plugin-manifest-validator",
+  "name": "@kintone/plugin-manifest-validator",
   "version": "0.7.0",
   "author": "Teppei Sato <teppeis@gmail.com>",
   "engines": {
@@ -34,13 +34,13 @@
     "prettier": "1.12.1",
     "typescript": "^2.8.3"
   },
-  "homepage": "https://github.com/teppeis/kintone-plugin-manifest-validator#readme",
+  "homepage": "https://github.com/kintone/plugin-manifest-validator#readme",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/teppeis/kintone-plugin-manifest-validator.git"
+    "url": "git+ssh://git@github.com/kintone/plugin-manifest-validator.git"
   },
   "bugs": {
-    "url": "https://github.com/teppeis/kintone-plugin-manifest-validator/issues"
+    "url": "https://github.com/kintone/plugin-manifest-validator/issues"
   },
   "keywords": [],
   "license": "MIT"


### PR DESCRIPTION
BREAKING CHANGE: The GitHub repository and the npm package are now kintone organization from teppeis